### PR TITLE
Assume local environment if no local settings have been defined.

### DIFF
--- a/src/settings/settings.php
+++ b/src/settings/settings.php
@@ -27,7 +27,7 @@ if (!defined('SETTINGS_ENVIRONMENT')) {
 }
 
 // Assume the site is running on vdd if no hosting settings have been defined.
-if (!defined('SETTINGS_ENVIRONMENT')) {
+if (!defined('SETTINGS_HOSTING')) {
   define('SETTINGS_HOSTING', 'vdd');
 }
 

--- a/src/settings/settings.php
+++ b/src/settings/settings.php
@@ -19,7 +19,15 @@ $base_domains = [
 $local_settings = '/var/www/settings/PROJECT/settings.inc';
 if (file_exists($local_settings)) {
   require_once $local_settings;
+}
+
+// Assume local development environment if no environment has been defined.
+if (!defined('SETTINGS_ENVIRONMENT')) {
   define('SETTINGS_ENVIRONMENT', 'local');
+}
+
+// Assume the site is running on vdd if no hosting settings have been defined.
+if (!defined('SETTINGS_ENVIRONMENT')) {
   define('SETTINGS_HOSTING', 'vdd');
 }
 


### PR DESCRIPTION
Currently the site throws notices when trying to install/use it after running `make`. This is because the settings file only sets the `SETTINGS_ENVIRONMENT` and `SETTINGS_HOSTING` constants when a local settings file exists, but all subsequently loaded settings files assume they have been set.

This PR changes the logic to always assume a local development environment if these constants haven't been defined in any local settings.