### PR TITLE
Drupal requires default settings during installation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -71,7 +71,9 @@
     "drupal-scaffold": {
       "omit-defaults": true,
       "includes": [
-        "index.php"
+        "index.php",
+        "sites/default/default.settings.php",
+        "sites/default/default.services.yml"
       ],
       "initial": {
         ".htaccess": ".htaccess",


### PR DESCRIPTION
Drupal requires default.settings.php and default.services.yml to be present during installation.