### PR TITLE
Executing phpunit in the root currently fails

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,4 +1,6 @@
 <phpunit
+        bootstrap="web/core/tests/bootstrap.php"
+        colors="true"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.5/phpunit.xsd"
         convertErrorsToExceptions="true"


### PR DESCRIPTION
There is a phpunit.xml file in the root of the repository. The intention with this appears to be to run all unit tests created in custom modules. However executing this currently fails with the error

```PHP Fatal error: Class 'Drupal\Tests\UnitTestCase' not found in ...```

The Drupal test environment needs to be bootstrapped first for custom tests to run.

Added bootstrap line to phpunit.xml file which is needed to properly run the phpunit tests