### PR TITLE
Use docroot instead of web as the primary build directory for wider…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -81,11 +81,11 @@
       }
     },
     "installer-paths": {
-      "web/core": ["type:drupal-core"],
-      "web/libraries/{$name}": ["type:drupal-library"],
-      "web/modules/contrib/{$name}": ["type:drupal-module"],
-      "web/profiles/contrib/{$name}": ["type:drupal-profile"],
-      "web/themes/contrib/{$name}": ["type:drupal-theme"],
+      "docroot/core": ["type:drupal-core"],
+      "docroot/libraries/{$name}": ["type:drupal-library"],
+      "docroot/modules/contrib/{$name}": ["type:drupal-module"],
+      "docroot/profiles/contrib/{$name}": ["type:drupal-profile"],
+      "docroot/themes/contrib/{$name}": ["type:drupal-theme"],
       "drush/contrib/{$name}": ["type:drupal-drush"]
     }
   }

--- a/scripts/composer/DeesonScriptHandler.php
+++ b/scripts/composer/DeesonScriptHandler.php
@@ -13,7 +13,7 @@ use Symfony\Component\Filesystem\Filesystem;
 class DeesonScriptHandler {
 
   protected static function getDrupalRoot($project_root) {
-    return $project_root . '/web';
+    return $project_root . '/docroot';
   }
 
   public static function createRequiredFiles(Event $event) {
@@ -21,9 +21,9 @@ class DeesonScriptHandler {
     $project_root = getcwd();
     $drupal_root = static::getDrupalRoot($project_root);
 
-    // Create a docroot symlink.
-    if (!$fs->exists($project_root . '/docroot')) {
-      $fs->symlink('web', $project_root . '/docroot');
+    // Create a web symlink.
+    if (!$fs->exists($project_root . '/web')) {
+      $fs->symlink('docroot', $project_root . '/web');
     }
 
     $dirs = [


### PR DESCRIPTION
…compatibility with Drupal hosting providers.

Acquia doesn't support docroot/ being a symlink, but Pantheon and Platform.sh do support symlinks so we're switching this around.