### PR TITLE
Extract coding standards tests into a separate script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,12 +25,7 @@ build-prod:
 
 # Run coding standards checks.
 test-code-quality: build-dev
-	# Configure Drupal Coder support.
-	${ROOT_DIR}/vendor/bin/phpcs --config-set installed_paths ${ROOT_DIR}/vendor/drupal/coder/coder_sniffer
-	# Run the coding standards checks.
-	${ROOT_DIR}/vendor/bin/phpcs -nq --standard=Drupal --extensions=php,inc,module,theme ${ROOT_DIR}/src/
-	# Run the Drupal best practice checks.
-	${ROOT_DIR}/vendor/bin/phpcs -nq --standard=DrupalPractice --extensions=php,inc,module,theme ${ROOT_DIR}/src/
+	./scripts/make/code_standards.sh
 # Run unit tests.
 test-phpunit: build-dev
 	${ROOT_DIR}/vendor/bin/phpunit
@@ -42,7 +37,7 @@ test: build-dev test-code-quality test-phpunit test-behat
 
 # Deploy to hosting. Builds prod dependencies first. Tests MUST pass.
 deploy:	test build-prod
-	if $(RUN_DESTRUCTIVE); then ./scripts/deploy.sh; else exit 1; fi
+	if $(RUN_DESTRUCTIVE); then ./scripts/make/deploy.sh; else exit 1; fi
 
 # Cleanup
 clean:

--- a/scripts/make/build.sh
+++ b/scripts/make/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+# Placeholder for the build script.

--- a/scripts/make/code_standards.sh
+++ b/scripts/make/code_standards.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+PHPCS_CHECK_DIR=$1
+PHPCS_PATH="vendor/bin/phpcs"
+PHPCBF_PATH="vendor/bin/phpcbf"
+PHPCS_EXTENSIONS="php,inc,module,theme"
+DRUPAL_EXCLUDED_SNIFFS=(
+    Drupal.Commenting.DocComment
+    Drupal.Commenting.ClassComment
+)
+IGNORE="src/frontend/assets"
+IGNORE="$IGNORE,src/frontend/node_modules"
+IGNORE="$IGNORE,src/themes/cc_admin_theme/css"
+IGNORE="$IGNORE,src/frontend/src/font"
+
+echo "Running coding standard checks in ${PHPCS_CHECK_DIR}"
+
+
+# Configure Drupal Coder support.
+${PHPCS_PATH} --config-set installed_paths vendor/drupal/coder/coder_sniffer
+
+# Run the coding standards checks.
+EXCLUDE=$(IFS=, ; echo "${DRUPAL_EXCLUDED_SNIFFS[*]}")
+${PHPCS_PATH} -nq --standard=Drupal --extensions=${PHPCS_EXTENSIONS} --exclude=${EXCLUDE} --ignore=${IGNORE} ${PHPCS_CHECK_DIR}
+if [ $? != 0 ]
+then
+    exit 1
+fi
+
+# Run the Drupal best practice checks.
+${PHPCS_PATH} -nq --standard=DrupalPractice --extensions=${PHPCS_EXTENSIONS} --ignore=${IGNORE} ${PHPCS_CHECK_DIR}
+if [ $? != 0 ]
+then
+    exit 1
+fi


### PR DESCRIPTION
To allow us to add support for ignore rules without polluting the makefile.

Some of these ignore rules are part of this PR to ignore the frontend framework assets, node_modules and such.