### PR TITLE
Remove docker-sync. Prefer docker-for-mac volume cache strategy.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,15 +70,15 @@ post-deploy:
 	cd docroot && $(DRUSH) cr
 	cd docroot && $(DRUSH) cc css-js
 
-# Start Docker using docker-sync
+# Start Docker
 docker-start: docker-up
 docker-up: docker-local-ssl
-	docker-sync start && docker-compose up -d
+	docker-compose up -d
 
-# Stop Docker and docker-sync
+# Stop Docker
 docker-stop: docker-down
 docker-down:
-	docker-compose down && docker-sync stop
+	docker-compose down
 
 # Restart docker
 docker-restart: docker-stop docker-start

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,6 @@ services:
       - 'traefik.port=3306'
       - 'traefik.frontend.rule=Host:localhost'
 
-
   php:
 # 2. Images without Drupal – wodby/drupal-php:[PHP_VERSION]-[STABILITY_TAG].
     image: wodby/drupal-php:7.1-2.4.3
@@ -39,10 +38,9 @@ services:
       PHP_XDEBUG_REMOTE_HOST: "10.254.254.254"  # You will also need to 'sudo ifconfig lo0 alias 10.254.254.254'
       PHP_IDE_CONFIG: "serverName=localhost"       # Needed for xdebug for drush commands.
     volumes:
-#     - ./:/var/www/html
+      - ./:/var/www/html:cached
       - ./.persist/public:/var/www/html/docroot/sites/default/files
       - ./.persist/private:/private
-      - docker-sync:/var/www/html:nocopy # Docker-sync for macOS users
 
   nginx:
 # wodby/drupal-nginx:[DRUPAL_VERSION]-[NGINX_VERSION]-[STABILITY_TAG].
@@ -57,9 +55,8 @@ services:
       NGINX_BACKEND_HOST: php
       NGINX_SERVER_ROOT: /var/www/html/docroot
     volumes:
-#     - ./:/var/www/html
+      - ./:/var/www/html:cached
       - ./.persist/public:/var/www/html/docroot/sites/default/files
-      - docker-sync:/var/www/html:nocopy # Docker-sync for macOS users
     labels:
       - 'traefik.backend=nginx'
       - 'traefik.port=80'
@@ -156,9 +153,3 @@ services:
       - '2223:22'
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-
-# Docker-sync for macOS users
-volumes:
-  docker-sync:
-    external:
-      name: "${COMPOSE_PROJECT_NAME}-docker-sync"

--- a/docker-sync.yml
+++ b/docker-sync.yml
@@ -1,9 +1,0 @@
-version: "2"
-
-#options:
-#  verbose: true
-syncs:
-  ${COMPOSE_PROJECT_NAME}-docker-sync:
-    src: './'
-    sync_userid: '82'
-    sync_excludes: ['.gitignore', '.git', '.idea', '.persist']


### PR DESCRIPTION
Initial testing has shown this to be on par with docker-sync from a performance perspective, and the host > container sync delay seems to be minimal.