### PR TITLE
Add command to stop all containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,10 @@ docker-down:
 # Restart docker
 docker-restart: docker-stop docker-start
 
+# Stop all running container
+docker-stop-all:
+	docker stop $(docker ps -aq)
+
 docker-local-ssl: .persist/certs/local.key .persist/certs/local.crt
 .persist/certs/local.%:
 	mkdir -p ./.persist/certs


### PR DESCRIPTION
This adds a make command which will stop all running containers on the system, regardless of which docker-compose file started them.

When switching between a few different projects there are times when I've left containers running from other projects and had to CD into the correct project directory just to tell docker-compose to stop the running containers. This new command will stop everything without the need for docker-compose.