### PR TITLE
Adding default libraries.yml file given it's defined in the theme's i…

### DIFF
--- a/src/themes/deeson_frontend_framework/deeson_frontend_framework.libraries.yml
+++ b/src/themes/deeson_frontend_framework/deeson_frontend_framework.libraries.yml
@@ -1,0 +1,8 @@
+base:
+  css:
+    theme:
+      assets/app.css: {}
+  js:
+    assets/app.js: {}
+  dependencies:
+    - core/drupalSettings


### PR DESCRIPTION
In `deeson_frontend_framework.info.yml` a `base` library is defined to be included on every page, yet the `libraries.yml` file and library need to be defined.

This PR defines a default file by pulling in `asset/app.css` and `assets/app.js`.