### PR TITLE
Stop drush wrapper complaining about error in preflight

### DIFF
--- a/drush.wrapper
+++ b/drush.wrapper
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 #
 # DRUSH WRAPPER
 # This wrapper script enables Drush to be seamlessly run inside of our PHP
@@ -34,7 +34,11 @@ if [[ $@ == *"@docker"* ]]; then
     if [ -t 0 -a -t 1 ]; then
         ARGS="-it"
     fi;
-    docker exec $ARGS $CONTAINER ./vendor/bin/drush.launcher --local --alias-path=./drush --reserve-margin=80 "$@"
+
+    # Tell Docker the number of columns in our terminal.
+    ARGS="${ARGS} -e COLUMNS="`tput cols`
+
+    docker exec $ARGS $CONTAINER ./vendor/bin/drush.launcher --local --alias-path=./drush "$@"
 else
-    ${basename}/vendor/bin/drush.launcher --alias-path=./drush  --reserve-margin=80 "$@"
+    ${basename}/vendor/bin/drush.launcher --alias-path=./drush "$@"
 fi

--- a/drush.wrapper
+++ b/drush.wrapper
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 #
 # DRUSH WRAPPER
 # This wrapper script enables Drush to be seamlessly run inside of our PHP

--- a/drush.wrapper
+++ b/drush.wrapper
@@ -34,7 +34,7 @@ if [[ $@ == *"@docker"* ]]; then
     if [ -t 0 -a -t 1 ]; then
         ARGS="-it"
     fi;
-    docker exec $ARGS $CONTAINER ./vendor/bin/drush.launcher --local --alias-path=./drush "$@"
+    docker exec $ARGS $CONTAINER ./vendor/bin/drush.launcher --local --alias-path=./drush --reserve-margin=80 "$@"
 else
-    ${basename}/vendor/bin/drush.launcher --alias-path=./drush "$@"
+    ${basename}/vendor/bin/drush.launcher --alias-path=./drush  --reserve-margin=80 "$@"
 fi


### PR DESCRIPTION
When using the excellent drush.wrapper one often gets the error `A non-numeric value encountered preflight.inc:468` followed by all command line output being forced into a narrow column in the terminal.

I tracked it down to some weirdness that can be hidden by specifying the column width when executing drush commands. 