### PR TITLE
More effective cache disabling

### DIFF
--- a/src/settings/91-local.settings.inc
+++ b/src/settings/91-local.settings.inc
@@ -49,26 +49,10 @@ if (SETTINGS_ENVIRONMENT == 'local') {
   $config['system.performance']['js']['preprocess'] = FALSE;
 
   /*
-   * Disable the render cache (this includes the page cache).
-   *
-   * Note: you should test with the render cache enabled, to ensure the correct
-   * cacheability metadata is present. However, in the early stages of
-   * development, you may want to disable it.
-   *
-   * This setting disables the render cache by using the Null cache back-end
-   * defined by the development.services.yml file above.
-   *
-   * Do not use this setting until after the site is installed.
+   * Disable the caches.
    */
   $settings['cache']['bins']['render'] = 'cache.backend.null';
-
-  /*
-   * Disable Dynamic Page Cache.
-   *
-   * Note: you should test with Dynamic Page Cache enabled, to ensure the correct
-   * cacheability metadata is present (and hence the expected behavior). However,
-   * in the early stages of development, you may want to disable it.
-   */
+  $settings['cache']['bins']['page'] = 'cache.backend.null';
   $settings['cache']['bins']['dynamic_page_cache'] = 'cache.backend.null';
 
   /*


### PR DESCRIPTION
Because disabling render cache no longer disables page cache. See https://www.drupal.org/node/2598914 ("If you are using Drupal version greater than or equal to 8.4 then add the following lines to your settings.local.php").