### PR TITLE
added datalayer as a standard module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
     "drupal/config_split": "^1.4",
     "drupal/console": "~1.0",
     "drupal/core": "8.6.3",
+    "drupal/datalayer": "1.x-dev",
     "drupal/drupal-extension": "^3.2",
     "drupal/entity": "^1.0@alpha",
     "drupal/google_analytics": "^2.1",


### PR DESCRIPTION
Datalayer module puts some data onto the page in a JS variable called datalayer.

Google Analytics picks this up and allows the analytics guy (Nick) to segment data in new and exciting ways.

Its been suggested this should be added as standard.  Vote now.