### PR TITLE
Update to latest version of Composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,9 @@
     }
   ],
   "require": {
-    "composer/installers": "^1.2",
+    "composer/installers": "^1.6",
     "cweagans/composer-patches": "1.x-dev",
-    "drupal-composer/drupal-scaffold": "^2.2",
+    "drupal-composer/drupal-scaffold": "^2.5",
     "drupal/components": "^1.0",
     "drupal/config_filter": "^1.3",
     "drupal/config_split": "^1.4",

--- a/scripts/make/install-drupal.sh
+++ b/scripts/make/install-drupal.sh
@@ -9,7 +9,7 @@ repo_root=$(pwd)
 source "$repo_root/.build.env"
 
 if [ "$drupal_build_composer_install" == "Y" ]; then
-  composer install
+  composer self-update && composer install
 fi
 
 if [ "$drupal_build_drush_make" == "Y" ]; then


### PR DESCRIPTION
Update to latest version of Composer and required Drupal dependencies so Drupal libraries are installed without needing to run Composer a second time.