### PR TITLE
Added code to enable pipelines build with new bootstrap-build-framework.sh script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,10 @@ clean-drupal: clean-composer
 # Targets for Bitbucket Pipelines
 #
 
+# Bootstrap scripts/make directory
+pipelines-bootstrap:
+    ./scripts/bootstrap-build-framework.sh
+
 # Build Drupal under Pipelnes.
 pipelines-build-drupal:
 	./scripts/make/install-drupal.sh

--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ clean-drupal: clean-composer
 
 # Bootstrap scripts/make directory
 pipelines-bootstrap:
-    ./scripts/bootstrap-build-framework.sh
+	./scripts/bootstrap-build-framework.sh
 
 # Build Drupal under Pipelnes.
 pipelines-build-drupal:

--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -5,6 +5,13 @@ pipelines:
   branches:
     master:
       - step:
+            name: Bootstrap
+            image: deeson/deployer
+            script:
+              - make pipelines-bootstrap
+            artifacts:
+              - 'scripts/make/**'
+      - step:
           name: Build Drupal
           image: wodby/drupal-php:7.1-2.4.3
           caches:
@@ -39,6 +46,13 @@ pipelines:
           script:
             - make pipelines-deploy
     develop:
+      - step:
+          name: Bootstrap
+          image: deeson/deployer
+          script:
+            - make pipelines-bootstrap
+          artifacts:
+            - 'scripts/make/**'
       - step:
           name: Build Drupal
           image: wodby/drupal-php:7.1-2.4.3
@@ -75,6 +89,13 @@ pipelines:
             - make pipelines-deploy
     UAT:
       - step:
+          name: Bootstrap
+          image: deeson/deployer
+          script:
+            - make pipelines-bootstrap
+          artifacts:
+            - 'scripts/make/**'
+      - step:
           name: Build Drupal
           image: wodby/drupal-php:7.1-2.4.3
           caches:
@@ -110,6 +131,13 @@ pipelines:
             - make pipelines-deploy
   tags:
     '*':
+      - step:
+          name: Bootstrap
+          image: deeson/deployer
+          script:
+            - make pipelines-bootstrap
+          artifacts:
+            - 'scripts/make/**'
       - step:
           name: Build Drupal
           image: wodby/drupal-php:7.1-2.4.3

--- a/scripts/bootstrap-build-framework.sh
+++ b/scripts/bootstrap-build-framework.sh
@@ -12,8 +12,15 @@ if [ ! -d "./make" ]; then
     version=$(cat ./.dbf)
   fi
 
-  docker run -v $(pwd):/app -w /app --env DBFVER=$version deeson/deployer /bin/bash \
-    -c 'git clone -b "$DBFVER" --single-branch --depth 1 https://github.com/teamdeeson/drupal-build-framework.git make \
+  DBFVER=$version
+  clone_script='git clone -b "$DBFVER" --single-branch --depth 1 https://github.com/teamdeeson/drupal-build-framework.git make \
     && cd ./make \
-    && rm -Rf .git'
+    && rm -Rf .git';
+
+  #If were not under pipelines, run in container, otherwise we're already in a container, run locally.
+  if [ -z "$CI" ]; then
+  docker run -v $(pwd):/app -w /app --env DBFVER=$version deeson/deployer /bin/bash -c "$clone_script"
+  else
+    eval "$clone_script"
+  fi
 fi


### PR DESCRIPTION
Added bootstrap step to all pipelines. This produces the scripts/make directory as an artifact.

Altered the boostrap-build-framework.sh script to tell if it is running under bb pipelines.
If it is running under pipelines, then it need not run its clone_script in a container, as its already the right one (deeson/deployer).

Added a pipelines-boostrap target to Makefile.